### PR TITLE
feat: CLI entry point with command parsing

### DIFF
--- a/bin/source-verse.ts
+++ b/bin/source-verse.ts
@@ -2,32 +2,20 @@
 /**
  * source-verse CLI entry point
  *
- * This is the binary stub for the `source-verse` CLI command.
- * Command parsing and feature logic will be added in future issues.
+ * Validates we're in a git repository, then delegates to Commander
+ * for command parsing and dispatch.
  */
 
-const [, , ...args] = process.argv;
+import { assertGitRepository } from '../src/git/validation.js';
+import { createProgram } from '../src/cli/program.js';
 
-function main(argv: string[]): void {
-  if (argv.length === 0) {
-    console.log('source-verse — parallel Claude Code session manager');
-    console.log('');
-    console.log('Usage: source-verse [command]');
-    console.log('');
-    console.log('Commands:');
-    console.log('  (coming soon)');
-    console.log('');
-    console.log('Run source-verse --help for more information.');
-    return;
-  }
-
-  if (argv[0] === '--version' || argv[0] === '-v') {
-    console.log('0.1.0');
-    return;
-  }
-
-  console.log(`Unknown command: ${argv[0]}`);
-  process.exit(1);
+async function main(): Promise<void> {
+  await assertGitRepository(process.cwd());
+  const program = createProgram();
+  await program.parseAsync(process.argv);
 }
 
-main(args);
+main().catch((error: Error) => {
+  console.error(error.message);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -36,5 +36,8 @@
     "typescript": "5.9.3",
     "vitest": "3.0.8"
   },
-  "packageManager": "pnpm@10.23.0"
+  "packageManager": "pnpm@10.23.0",
+  "dependencies": {
+    "commander": "14.0.3"
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      commander:
+        specifier: ^14.0.3
+        version: 14.0.3
     devDependencies:
       '@types/node':
         specifier: 22.13.9
@@ -540,6 +544,10 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -1457,6 +1465,8 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  commander@14.0.3: {}
 
   concat-map@0.0.1: {}
 

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -1,0 +1,23 @@
+export function handleNew(task: string): void {
+  console.log(`new: not implemented yet (task: "${task}")`);
+}
+
+export function handleList(): void {
+  console.log('list: not implemented yet');
+}
+
+export function handleSwitch(sessionId: string): void {
+  console.log(`switch: not implemented yet (session: ${sessionId})`);
+}
+
+export function handleStop(sessionId: string): void {
+  console.log(`stop: not implemented yet (session: ${sessionId})`);
+}
+
+export function handleCleanup(): void {
+  console.log('cleanup: not implemented yet');
+}
+
+export function handleStatus(): void {
+  console.log('status: not implemented yet');
+}

--- a/src/cli/program.test.ts
+++ b/src/cli/program.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createProgram } from './program.js';
+
+vi.mock('./commands.js', () => ({
+  handleNew: vi.fn(),
+  handleList: vi.fn(),
+  handleSwitch: vi.fn(),
+  handleStop: vi.fn(),
+  handleCleanup: vi.fn(),
+  handleStatus: vi.fn(),
+}));
+
+import {
+  handleNew,
+  handleList,
+  handleSwitch,
+  handleStop,
+  handleCleanup,
+  handleStatus,
+} from './commands.js';
+
+function parseArgs(...args: string[]) {
+  const program = createProgram();
+  program.exitOverride();
+  program.configureOutput({
+    writeOut: () => {},
+    writeErr: () => {},
+  });
+  return program.parseAsync(['node', 'source-verse', ...args]);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('createProgram', () => {
+  it('shows welcome message when no subcommand is given', async () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await parseArgs();
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('source-verse'),
+    );
+    consoleSpy.mockRestore();
+  });
+
+  it('prints version with --version flag', async () => {
+    await expect(parseArgs('--version')).rejects.toThrow();
+  });
+
+  it('prints help with --help flag', async () => {
+    await expect(parseArgs('--help')).rejects.toThrow();
+  });
+
+  it('calls handleNew with task argument', async () => {
+    await parseArgs('new', 'fix login bug');
+    expect(handleNew).toHaveBeenCalledWith('fix login bug');
+  });
+
+  it('calls handleList for list command', async () => {
+    await parseArgs('list');
+    expect(handleList).toHaveBeenCalled();
+  });
+
+  it('calls handleSwitch with session id', async () => {
+    await parseArgs('switch', '3');
+    expect(handleSwitch).toHaveBeenCalledWith('3');
+  });
+
+  it('calls handleStop with session id', async () => {
+    await parseArgs('stop', '2');
+    expect(handleStop).toHaveBeenCalledWith('2');
+  });
+
+  it('calls handleCleanup for cleanup command', async () => {
+    await parseArgs('cleanup');
+    expect(handleCleanup).toHaveBeenCalled();
+  });
+
+  it('calls handleStatus for status command', async () => {
+    await parseArgs('status');
+    expect(handleStatus).toHaveBeenCalled();
+  });
+
+  it('rejects unknown commands', async () => {
+    await expect(parseArgs('unknown')).rejects.toThrow();
+  });
+
+  it('rejects new command without task argument', async () => {
+    await expect(parseArgs('new')).rejects.toThrow();
+  });
+
+  it('rejects switch command without id argument', async () => {
+    await expect(parseArgs('switch')).rejects.toThrow();
+  });
+
+  it('rejects stop command without id argument', async () => {
+    await expect(parseArgs('stop')).rejects.toThrow();
+  });
+});

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -1,0 +1,78 @@
+import { Command } from 'commander';
+import { createRequire } from 'node:module';
+import {
+  handleNew,
+  handleList,
+  handleSwitch,
+  handleStop,
+  handleCleanup,
+  handleStatus,
+} from './commands.js';
+
+const require = createRequire(import.meta.url);
+const { version } = require('../../package.json') as { version: string };
+
+const WELCOME_MESSAGE = `
+  source-verse — parallel Claude Code session manager
+
+  No active sessions.
+
+  Press [n] to create a new session
+  or run: source-verse new "fix the login bug"
+`;
+
+export function createProgram(): Command {
+  const program = new Command();
+
+  program
+    .name('source-verse')
+    .description('Run multiple Claude Code sessions in parallel from a single terminal')
+    .version(version, '-V, --version')
+    .action(() => {
+      console.log(WELCOME_MESSAGE);
+    });
+
+  program
+    .command('new <task>')
+    .description('Create a new session with the given task description')
+    .action((task: string) => {
+      handleNew(task);
+    });
+
+  program
+    .command('list')
+    .description('List all active sessions with their status')
+    .action(() => {
+      handleList();
+    });
+
+  program
+    .command('switch <id>')
+    .description('Switch the terminal view to a specific session')
+    .action((id: string) => {
+      handleSwitch(id);
+    });
+
+  program
+    .command('stop <id>')
+    .description('Stop a session and optionally clean up its repo copy')
+    .action((id: string) => {
+      handleStop(id);
+    });
+
+  program
+    .command('cleanup')
+    .description('Remove all completed/merged session repo copies')
+    .action(() => {
+      handleCleanup();
+    });
+
+  program
+    .command('status')
+    .description('Show a summary of all sessions and their states')
+    .action(() => {
+      handleStatus();
+    });
+
+  return program;
+}

--- a/src/git/validation.test.ts
+++ b/src/git/validation.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, mkdir, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { isGitRepository, assertGitRepository } from './validation.js';
+
+describe('isGitRepository', () => {
+  it('returns true when .git directory exists', async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'sv-test-'));
+    try {
+      await mkdir(join(tempDir, '.git'));
+      expect(await isGitRepository(tempDir)).toBe(true);
+    } finally {
+      await rm(tempDir, { recursive: true });
+    }
+  });
+
+  it('returns false when .git directory does not exist', async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'sv-test-'));
+    try {
+      expect(await isGitRepository(tempDir)).toBe(false);
+    } finally {
+      await rm(tempDir, { recursive: true });
+    }
+  });
+
+  it('returns false for a nonexistent directory', async () => {
+    expect(await isGitRepository('/tmp/nonexistent-sv-test-dir')).toBe(false);
+  });
+});
+
+describe('assertGitRepository', () => {
+  it('resolves for a git repository', async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'sv-test-'));
+    try {
+      await mkdir(join(tempDir, '.git'));
+      await expect(assertGitRepository(tempDir)).resolves.toBeUndefined();
+    } finally {
+      await rm(tempDir, { recursive: true });
+    }
+  });
+
+  it('throws with a clear message for a non-git directory', async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'sv-test-'));
+    try {
+      await expect(assertGitRepository(tempDir)).rejects.toThrow(
+        'Not a git repository',
+      );
+    } finally {
+      await rm(tempDir, { recursive: true });
+    }
+  });
+});

--- a/src/git/validation.ts
+++ b/src/git/validation.ts
@@ -1,0 +1,20 @@
+import { access, constants } from 'node:fs/promises';
+import { join } from 'node:path';
+
+export async function isGitRepository(directory: string): Promise<boolean> {
+  try {
+    await access(join(directory, '.git'), constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function assertGitRepository(directory: string): Promise<void> {
+  const isRepo = await isGitRepository(directory);
+  if (!isRepo) {
+    throw new Error(
+      `Not a git repository: ${directory}\nRun this command from inside a git repository.`,
+    );
+  }
+}

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,16 +1,16 @@
 import { describe, it, expect } from 'vitest';
+import { createProgram, isGitRepository, assertGitRepository } from './index.js';
 
-/**
- * Placeholder test suite.
- * Real tests will be added alongside feature implementations.
- */
-describe('source-verse', () => {
-  it('placeholder — scaffolding is set up correctly', () => {
-    expect(true).toBe(true);
+describe('public API exports', () => {
+  it('exports createProgram', () => {
+    expect(typeof createProgram).toBe('function');
   });
 
-  it('environment is Node.js', () => {
-    expect(typeof process).toBe('object');
-    expect(typeof process.version).toBe('string');
+  it('exports isGitRepository', () => {
+    expect(typeof isGitRepository).toBe('function');
+  });
+
+  it('exports assertGitRepository', () => {
+    expect(typeof assertGitRepository).toBe('function');
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,9 @@
 /**
- * source-verse — entry point
- *
- * This module is the public API surface for source-verse.
- * Features will be exported from here as they are implemented.
+ * source-verse — public API surface
  *
  * Module system: ESM (type: "module" in package.json)
  * Node.js target: ES2022 / NodeNext
  */
 
-// No exports yet — placeholder for future implementation
-export {};
+export { createProgram } from './cli/program.js';
+export { isGitRepository, assertGitRepository } from './git/validation.js';


### PR DESCRIPTION
## Summary

Set up the CLI binary (`source-verse`) with Commander.js for command parsing. All planned subcommands are wired up as stubs that print "not implemented yet." The CLI validates that the current directory is a git repository and exits with a clear error if not.

## Changes

- Added `commander` (14.0.3) as a production dependency
- Created `src/git/validation.ts` — git repository detection utility (`isGitRepository`, `assertGitRepository`)
- Created `src/cli/program.ts` — Commander program with all subcommands configured
- Created `src/cli/commands.ts` — stub handlers for `new`, `list`, `switch`, `stop`, `cleanup`, `status`
- Updated `bin/source-verse.ts` — validates git repo, then delegates to Commander
- Updated `src/index.ts` — exports public API surface
- Added 21 tests covering CLI argument parsing, git repo validation, and public exports

## Testing

- `pnpm test` — 21 tests passing across 3 test files
- `pnpm lint` — clean
- `pnpm build` — compiles without errors
- Manual verification: `--version`, `--help`, welcome message, stub commands, and non-git-repo error all work correctly

Closes #5