### PR TITLE
feat: wire source-verse new to create worktree + branch

### DIFF
--- a/src/cli/commands.test.ts
+++ b/src/cli/commands.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../git/manager.js', () => ({
+  GitManager: vi.fn(),
+}));
+
+vi.mock('../git/slugify.js', () => ({
+  slugifyTaskName: vi.fn(),
+}));
+
+import { handleNew } from './commands.js';
+import { GitManager } from '../git/manager.js';
+import { slugifyTaskName } from '../git/slugify.js';
+
+const mockSlugify = vi.mocked(slugifyTaskName);
+const MockGitManager = vi.mocked(GitManager);
+
+function createMockManager() {
+  return {
+    listWorktrees: vi.fn(),
+    createWorktree: vi.fn(),
+    getDefaultBranch: vi.fn(),
+    removeWorktree: vi.fn(),
+    isBranchMerged: vi.fn(),
+  };
+}
+
+describe('handleNew', () => {
+  let mockManager: ReturnType<typeof createMockManager>;
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockManager = createMockManager();
+    MockGitManager.mockImplementation(() => mockManager as unknown as GitManager);
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  it('creates worktree with slugified branch name', async () => {
+    mockSlugify.mockReturnValue('sv/fix-login-bug');
+    mockManager.listWorktrees.mockResolvedValue([]);
+    mockManager.createWorktree.mockResolvedValue('/projects/my-app-sv-1');
+    mockManager.getDefaultBranch.mockResolvedValue('main');
+
+    await handleNew('fix login bug', '/projects/my-app');
+
+    expect(mockSlugify).toHaveBeenCalledWith('fix login bug');
+    expect(mockManager.createWorktree).toHaveBeenCalledWith('1', 'sv/fix-login-bug');
+  });
+
+  it('generates session id 1 when no existing worktrees', async () => {
+    mockSlugify.mockReturnValue('sv/task');
+    mockManager.listWorktrees.mockResolvedValue([]);
+    mockManager.createWorktree.mockResolvedValue('/projects/app-sv-1');
+    mockManager.getDefaultBranch.mockResolvedValue('main');
+
+    await handleNew('task', '/projects/app');
+
+    expect(mockManager.createWorktree).toHaveBeenCalledWith('1', 'sv/task');
+  });
+
+  it('increments session id based on existing worktrees', async () => {
+    mockSlugify.mockReturnValue('sv/new-task');
+    mockManager.listWorktrees.mockResolvedValue([
+      { path: '/projects/app-sv-1', branch: 'sv/old', sessionId: '1' },
+      { path: '/projects/app-sv-3', branch: 'sv/other', sessionId: '3' },
+    ]);
+    mockManager.createWorktree.mockResolvedValue('/projects/app-sv-4');
+    mockManager.getDefaultBranch.mockResolvedValue('main');
+
+    await handleNew('new task', '/projects/app');
+
+    expect(mockManager.createWorktree).toHaveBeenCalledWith('4', 'sv/new-task');
+  });
+
+  it('prints success message with worktree path and branch', async () => {
+    mockSlugify.mockReturnValue('sv/fix-login-bug');
+    mockManager.listWorktrees.mockResolvedValue([]);
+    mockManager.createWorktree.mockResolvedValue('/projects/my-app-sv-1');
+    mockManager.getDefaultBranch.mockResolvedValue('main');
+
+    await handleNew('fix login bug', '/projects/my-app');
+
+    const output = consoleSpy.mock.calls.map((call) => call[0]).join('\n');
+    expect(output).toContain('Created worktree: /projects/my-app-sv-1');
+    expect(output).toContain('Branched: sv/fix-login-bug (from main)');
+  });
+
+  it('prints correct default branch in success message', async () => {
+    mockSlugify.mockReturnValue('sv/task');
+    mockManager.listWorktrees.mockResolvedValue([]);
+    mockManager.createWorktree.mockResolvedValue('/projects/app-sv-1');
+    mockManager.getDefaultBranch.mockResolvedValue('master');
+
+    await handleNew('task', '/projects/app');
+
+    const output = consoleSpy.mock.calls.map((call) => call[0]).join('\n');
+    expect(output).toContain('(from master)');
+  });
+
+  it('propagates errors from GitManager', async () => {
+    mockSlugify.mockReturnValue('sv/task');
+    mockManager.listWorktrees.mockResolvedValue([]);
+    mockManager.createWorktree.mockRejectedValue(new Error('Branch "sv/task" already exists.'));
+
+    await expect(handleNew('task', '/projects/app')).rejects.toThrow(
+      'Branch "sv/task" already exists.',
+    );
+  });
+
+  it('propagates errors from slugifyTaskName', async () => {
+    mockSlugify.mockImplementation(() => {
+      throw new Error('Task description cannot be empty');
+    });
+
+    await expect(handleNew('', '/projects/app')).rejects.toThrow(
+      'Task description cannot be empty',
+    );
+  });
+});

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -1,5 +1,26 @@
-export function handleNew(task: string): void {
-  console.log(`new: not implemented yet (task: "${task}")`);
+import { GitManager } from '../git/manager.js';
+import { slugifyTaskName } from '../git/slugify.js';
+
+
+async function generateSessionId(gitManager: GitManager): Promise<string> {
+  const existing = await gitManager.listWorktrees();
+  const usedIds = existing.map((worktree) => Number(worktree.sessionId)).filter(Number.isFinite);
+  const nextId = usedIds.length > 0 ? Math.max(...usedIds) + 1 : 1;
+  return String(nextId);
+}
+
+export async function handleNew(task: string, repoPath = process.cwd()): Promise<void> {
+  const gitManager = new GitManager(repoPath);
+  const branchName = slugifyTaskName(task);
+  const sessionId = await generateSessionId(gitManager);
+
+  const worktreePath = await gitManager.createWorktree(sessionId, branchName);
+  const defaultBranch = await gitManager.getDefaultBranch();
+
+  console.log('');
+  console.log(`  ✓ Created worktree: ${worktreePath}`);
+  console.log(`  ✓ Branched: ${branchName} (from ${defaultBranch})`);
+  console.log('');
 }
 
 export function handleList(): void {

--- a/src/cli/new-command.integration.test.ts
+++ b/src/cli/new-command.integration.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { existsSync } from 'node:fs';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { handleNew } from './commands.js';
+
+const exec = promisify(execFile);
+
+async function git(args: string[], cwd: string): Promise<string> {
+  const { stdout } = await exec('git', args, { cwd });
+  return stdout;
+}
+
+async function createTempRepo(): Promise<string> {
+  const tempDir = await mkdtemp(join(tmpdir(), 'sv-integration-'));
+  const repoDir = join(tempDir, 'my-app');
+  const bareDir = join(tempDir, 'origin.git');
+
+  // Create a bare "remote" repo
+  await git(['init', '--bare', bareDir], tempDir);
+
+  // Clone it to get a proper repo with remote
+  await git(['clone', bareDir, repoDir], tempDir);
+
+  // Configure git user for commits
+  await git(['config', 'user.email', 'test@test.com'], repoDir);
+  await git(['config', 'user.name', 'Test'], repoDir);
+
+  // Create initial commit on main
+  await git(['checkout', '-b', 'main'], repoDir);
+  await exec('touch', ['README.md'], { cwd: repoDir });
+  await git(['add', 'README.md'], repoDir);
+  await git(['commit', '-m', 'initial commit'], repoDir);
+  await git(['push', '-u', 'origin', 'main'], repoDir);
+
+  return repoDir;
+}
+
+describe('handleNew integration', () => {
+  let repoDir: string;
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    repoDir = await createTempRepo();
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    consoleSpy.mockRestore();
+    // Clean up: temp dir is parent of parent (repoDir = tempDir/my-app)
+    const tempDir = join(repoDir, '..');
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('creates a worktree and branch for a new task', async () => {
+    await handleNew('fix the login bug', repoDir);
+
+    const worktreePath = join(repoDir, '..', 'my-app-sv-1');
+    expect(existsSync(worktreePath)).toBe(true);
+
+    // Verify the branch exists
+    const branches = await git(['branch', '--list', 'sv/fix-the-login-bug'], repoDir);
+    expect(branches.trim()).toContain('sv/fix-the-login-bug');
+  });
+
+  it('prints success output with worktree path and branch name', async () => {
+    await handleNew('add user auth', repoDir);
+
+    const output = consoleSpy.mock.calls.map((call) => call[0]).join('\n');
+    expect(output).toContain('Created worktree:');
+    expect(output).toContain('my-app-sv-1');
+    expect(output).toContain('Branched: sv/add-user-auth (from main)');
+  });
+
+  it('increments session id for subsequent tasks', async () => {
+    await handleNew('first task', repoDir);
+    await handleNew('second task', repoDir);
+
+    const worktree1 = join(repoDir, '..', 'my-app-sv-1');
+    const worktree2 = join(repoDir, '..', 'my-app-sv-2');
+    expect(existsSync(worktree1)).toBe(true);
+    expect(existsSync(worktree2)).toBe(true);
+  });
+
+  it('throws when branch name already exists', async () => {
+    await handleNew('duplicate task', repoDir);
+
+    await expect(handleNew('duplicate task', repoDir)).rejects.toThrow(
+      'Branch "sv/duplicate-task" already exists',
+    );
+  });
+
+  it('worktree is checked out on the correct branch', async () => {
+    await handleNew('my feature', repoDir);
+
+    const worktreePath = join(repoDir, '..', 'my-app-sv-1');
+    const branch = await git(['rev-parse', '--abbrev-ref', 'HEAD'], worktreePath);
+    expect(branch.trim()).toBe('sv/my-feature');
+  });
+
+  it('worktree branch is based on latest origin/main', async () => {
+    await handleNew('based on main', repoDir);
+
+    const mainCommit = await git(['rev-parse', 'origin/main'], repoDir);
+    const worktreeBase = await git(['merge-base', 'sv/based-on-main', 'origin/main'], repoDir);
+    expect(worktreeBase.trim()).toBe(mainCommit.trim());
+  });
+});

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -35,8 +35,8 @@ export function createProgram(): Command {
   program
     .command('new <task>')
     .description('Create a new session with the given task description')
-    .action((task: string) => {
-      handleNew(task);
+    .action(async (task: string) => {
+      await handleNew(task);
     });
 
   program


### PR DESCRIPTION
## Summary

- Implement `handleNew` command handler that wires the CLI `new` command to `GitManager` and `slugifyTaskName`
- Generates sequential session IDs by inspecting existing worktrees
- Prints success output matching PRD section 9.3 format

## Changes

- `src/cli/commands.ts` — Implement `handleNew` with GitManager + slugify wiring, session ID generation, and formatted output
- `src/cli/program.ts` — Make `new` command action async to await `handleNew`
- `src/cli/commands.test.ts` — 7 unit tests with mocked GitManager covering happy path, ID generation, error propagation
- `src/cli/new-command.integration.test.ts` — 6 integration tests against real temporary git repos verifying worktree creation, branch checkout, session ID incrementing, and duplicate branch handling

## Testing

- 67 tests passing (all existing + 13 new)
- 0 lint errors
- Integration tests create real git repos with bare remotes in temp directories

Closes #7