### PR TITLE
feat: session state manager with JSON persistence

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -7,6 +7,7 @@ import {
   execGit,
   GitCommandError,
   slugifyTaskName,
+  SessionManager,
 } from './index.js';
 
 describe('public API exports', () => {
@@ -36,5 +37,9 @@ describe('public API exports', () => {
 
   it('exports slugifyTaskName', () => {
     expect(typeof slugifyTaskName).toBe('function');
+  });
+
+  it('exports SessionManager', () => {
+    expect(typeof SessionManager).toBe('function');
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,3 +11,5 @@ export { GitManager } from './git/manager.js';
 export type { WorktreeInfo } from './git/manager.js';
 export { execGit, GitCommandError } from './git/exec.js';
 export { slugifyTaskName } from './git/slugify.js';
+export { SessionManager } from './session/manager.js';
+export type { Session, SessionStatus } from './session/types.js';

--- a/src/session/manager.test.ts
+++ b/src/session/manager.test.ts
@@ -1,0 +1,221 @@
+import { mkdtemp, readFile, rm, writeFile, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { SessionManager } from './manager.js';
+import type { Session } from './types.js';
+
+describe('SessionManager', () => {
+  let tempDir: string;
+  let manager: SessionManager;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'sv-session-test-'));
+    manager = new SessionManager(tempDir);
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  describe('createSession', () => {
+    it('creates a session with all required fields', async () => {
+      const session = await manager.createSession('fix login bug', '/tmp/worktree', 'sv/fix-login');
+
+      expect(session.id).toBeDefined();
+      expect(session.id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+      );
+      expect(session.taskDescription).toBe('fix login bug');
+      expect(session.worktreePath).toBe('/tmp/worktree');
+      expect(session.branchName).toBe('sv/fix-login');
+      expect(session.status).toBe('created');
+      expect(session.pid).toBeNull();
+      expect(session.createdAt).toBeDefined();
+      expect(session.updatedAt).toBe(session.createdAt);
+    });
+
+    it('persists session to disk', async () => {
+      await manager.createSession('task one', '/tmp/wt1', 'sv/task-one');
+
+      const raw = await readFile(join(tempDir, 'sessions.json'), 'utf-8');
+      const sessions: Session[] = JSON.parse(raw);
+
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0].taskDescription).toBe('task one');
+    });
+
+    it('appends to existing sessions', async () => {
+      await manager.createSession('task one', '/tmp/wt1', 'sv/task-one');
+      await manager.createSession('task two', '/tmp/wt2', 'sv/task-two');
+
+      const sessions = await manager.listSessions();
+      expect(sessions).toHaveLength(2);
+    });
+
+    it('generates unique IDs for each session', async () => {
+      const first = await manager.createSession('task one', '/tmp/wt1', 'sv/task-one');
+      const second = await manager.createSession('task two', '/tmp/wt2', 'sv/task-two');
+
+      expect(first.id).not.toBe(second.id);
+    });
+  });
+
+  describe('getSession', () => {
+    it('returns the session by ID', async () => {
+      const created = await manager.createSession('my task', '/tmp/wt', 'sv/my-task');
+      const found = await manager.getSession(created.id);
+
+      expect(found).toEqual(created);
+    });
+
+    it('returns null for an unknown ID', async () => {
+      const found = await manager.getSession('nonexistent-id');
+      expect(found).toBeNull();
+    });
+
+    it('returns null when no sessions exist', async () => {
+      const found = await manager.getSession('any-id');
+      expect(found).toBeNull();
+    });
+  });
+
+  describe('listSessions', () => {
+    it('returns an empty array when no sessions exist', async () => {
+      const sessions = await manager.listSessions();
+      expect(sessions).toEqual([]);
+    });
+
+    it('returns sessions sorted by creation time', async () => {
+      const first = await manager.createSession('first', '/tmp/wt1', 'sv/first');
+
+      // Ensure distinct timestamps
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      const second = await manager.createSession('second', '/tmp/wt2', 'sv/second');
+
+      const sessions = await manager.listSessions();
+
+      expect(sessions).toHaveLength(2);
+      expect(sessions[0].id).toBe(first.id);
+      expect(sessions[1].id).toBe(second.id);
+    });
+  });
+
+  describe('updateStatus', () => {
+    it('updates the status of a session', async () => {
+      const created = await manager.createSession('task', '/tmp/wt', 'sv/task');
+      const updated = await manager.updateStatus(created.id, 'running');
+
+      expect(updated.status).toBe('running');
+    });
+
+    it('updates the updatedAt timestamp', async () => {
+      const created = await manager.createSession('task', '/tmp/wt', 'sv/task');
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      const updated = await manager.updateStatus(created.id, 'running');
+
+      expect(new Date(updated.updatedAt).getTime()).toBeGreaterThan(
+        new Date(created.updatedAt).getTime(),
+      );
+    });
+
+    it('persists the status change to disk', async () => {
+      const created = await manager.createSession('task', '/tmp/wt', 'sv/task');
+      await manager.updateStatus(created.id, 'done');
+
+      const freshManager = new SessionManager(tempDir);
+      const reloaded = await freshManager.getSession(created.id);
+
+      expect(reloaded?.status).toBe('done');
+    });
+
+    it('throws for an unknown session ID', async () => {
+      await expect(manager.updateStatus('nonexistent', 'running')).rejects.toThrow(
+        'Session not found: nonexistent',
+      );
+    });
+
+    it('supports all valid status transitions', async () => {
+      const session = await manager.createSession('task', '/tmp/wt', 'sv/task');
+
+      const statuses = ['running', 'waiting', 'done', 'merged', 'cleaned_up'] as const;
+
+      for (const status of statuses) {
+        const updated = await manager.updateStatus(session.id, status);
+        expect(updated.status).toBe(status);
+      }
+    });
+  });
+
+  describe('removeSession', () => {
+    it('removes a session by ID', async () => {
+      const created = await manager.createSession('task', '/tmp/wt', 'sv/task');
+      await manager.removeSession(created.id);
+
+      const found = await manager.getSession(created.id);
+      expect(found).toBeNull();
+    });
+
+    it('persists the removal to disk', async () => {
+      const created = await manager.createSession('task', '/tmp/wt', 'sv/task');
+      await manager.removeSession(created.id);
+
+      const freshManager = new SessionManager(tempDir);
+      const sessions = await freshManager.listSessions();
+      expect(sessions).toHaveLength(0);
+    });
+
+    it('does not affect other sessions', async () => {
+      const first = await manager.createSession('first', '/tmp/wt1', 'sv/first');
+      const second = await manager.createSession('second', '/tmp/wt2', 'sv/second');
+
+      await manager.removeSession(first.id);
+
+      const sessions = await manager.listSessions();
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0].id).toBe(second.id);
+    });
+
+    it('throws for an unknown session ID', async () => {
+      await expect(manager.removeSession('nonexistent')).rejects.toThrow(
+        'Session not found: nonexistent',
+      );
+    });
+  });
+
+  describe('edge cases', () => {
+    it('creates state directory if it does not exist', async () => {
+      const nestedDir = join(tempDir, 'nested', 'deep');
+      const nestedManager = new SessionManager(nestedDir);
+
+      await nestedManager.createSession('task', '/tmp/wt', 'sv/task');
+
+      const sessions = await nestedManager.listSessions();
+      expect(sessions).toHaveLength(1);
+    });
+
+    it('handles corrupt JSON gracefully', async () => {
+      await mkdir(tempDir, { recursive: true });
+      await writeFile(join(tempDir, 'sessions.json'), '{ broken json !!!', 'utf-8');
+
+      const sessions = await manager.listSessions();
+      expect(sessions).toEqual([]);
+    });
+
+    it('handles non-array JSON gracefully', async () => {
+      await mkdir(tempDir, { recursive: true });
+      await writeFile(join(tempDir, 'sessions.json'), '{"not": "an array"}', 'utf-8');
+
+      const sessions = await manager.listSessions();
+      expect(sessions).toEqual([]);
+    });
+
+    it('handles empty file gracefully', async () => {
+      await mkdir(tempDir, { recursive: true });
+      await writeFile(join(tempDir, 'sessions.json'), '', 'utf-8');
+
+      const sessions = await manager.listSessions();
+      expect(sessions).toEqual([]);
+    });
+  });
+});

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -1,0 +1,119 @@
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
+import { randomUUID } from 'node:crypto';
+import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { Session, SessionStatus } from './types.js';
+
+const DEFAULT_STATE_DIR = join(process.env.HOME ?? tmpdir(), '.source-verse');
+const SESSIONS_FILENAME = 'sessions.json';
+
+export class SessionManager {
+  private readonly stateFilePath: string;
+  private readonly stateDir: string;
+
+  constructor(stateDir = DEFAULT_STATE_DIR) {
+    this.stateDir = stateDir;
+    this.stateFilePath = join(stateDir, SESSIONS_FILENAME);
+  }
+
+  async createSession(
+    taskDescription: string,
+    worktreePath: string,
+    branchName: string,
+  ): Promise<Session> {
+    const sessions = await this.loadSessions();
+    const now = new Date().toISOString();
+
+    const session: Session = {
+      id: randomUUID(),
+      taskDescription,
+      worktreePath,
+      branchName,
+      status: 'created',
+      pid: null,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    sessions.push(session);
+    await this.saveSessions(sessions);
+    return session;
+  }
+
+  async getSession(id: string): Promise<Session | null> {
+    const sessions = await this.loadSessions();
+    return sessions.find((session) => session.id === id) ?? null;
+  }
+
+  async listSessions(): Promise<Session[]> {
+    const sessions = await this.loadSessions();
+    return sessions.sort(
+      (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+    );
+  }
+
+  async updateStatus(id: string, status: SessionStatus): Promise<Session> {
+    const sessions = await this.loadSessions();
+    const session = sessions.find((s) => s.id === id);
+
+    if (!session) {
+      throw new Error(`Session not found: ${id}`);
+    }
+
+    session.status = status;
+    session.updatedAt = new Date().toISOString();
+    await this.saveSessions(sessions);
+    return session;
+  }
+
+  async removeSession(id: string): Promise<void> {
+    const sessions = await this.loadSessions();
+    const index = sessions.findIndex((s) => s.id === id);
+
+    if (index === -1) {
+      throw new Error(`Session not found: ${id}`);
+    }
+
+    sessions.splice(index, 1);
+    await this.saveSessions(sessions);
+  }
+
+  private async loadSessions(): Promise<Session[]> {
+    try {
+      const data = await readFile(this.stateFilePath, 'utf-8');
+      const parsed: unknown = JSON.parse(data);
+
+      if (!Array.isArray(parsed)) {
+        return [];
+      }
+
+      return parsed as Session[];
+    } catch (error: unknown) {
+      const isFileNotFound =
+        error instanceof Error && 'code' in error && (error as NodeJS.ErrnoException).code === 'ENOENT';
+
+      if (isFileNotFound) {
+        return [];
+      }
+
+      if (error instanceof SyntaxError) {
+        return [];
+      }
+
+      throw error;
+    }
+  }
+
+  private async saveSessions(sessions: Session[]): Promise<void> {
+    await mkdir(this.stateDir, { recursive: true });
+
+    const tempPath = join(
+      dirname(this.stateFilePath),
+      `.sessions-${Date.now()}-${randomUUID().slice(0, 8)}.tmp`,
+    );
+    const data = JSON.stringify(sessions, null, 2) + '\n';
+
+    await writeFile(tempPath, data, 'utf-8');
+    await rename(tempPath, this.stateFilePath);
+  }
+}

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -1,0 +1,12 @@
+export type SessionStatus = 'created' | 'running' | 'waiting' | 'done' | 'merged' | 'cleaned_up';
+
+export interface Session {
+  id: string;
+  taskDescription: string;
+  worktreePath: string;
+  branchName: string;
+  status: SessionStatus;
+  pid: number | null;
+  createdAt: string;
+  updatedAt: string;
+}


### PR DESCRIPTION
## Summary

- Implement `SessionManager` class with full CRUD operations: `createSession`, `getSession`, `listSessions`, `updateStatus`, `removeSession`
- Persist session state to `~/.source-verse/sessions.json` using atomic writes (write-to-temp + rename) for safe concurrent access
- Auto-create `~/.source-verse/` directory on first write; gracefully handle missing, empty, or corrupt state files

## Changes

- `src/session/types.ts` — `Session` interface and `SessionStatus` type definition
- `src/session/manager.ts` — `SessionManager` class with JSON persistence
- `src/session/manager.test.ts` — 22 unit tests covering all CRUD operations and edge cases
- `src/index.ts` — Export `SessionManager`, `Session`, and `SessionStatus` from public API
- `src/index.test.ts` — Add export test for `SessionManager`

## Testing

All 90 tests pass (22 new + 68 existing). Tests cover:
- Create/read/update/delete operations
- Persistence across manager instances
- UUID generation and uniqueness
- Sorted listing by creation time
- Edge cases: missing directory, corrupt JSON, non-array JSON, empty file
- Error cases: unknown session ID for update/remove

Closes #8